### PR TITLE
Typo fix in the main Banner.

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ try{(new g(100,"r","QSI_S_ZN_8octL9QmYH5wQ9o","https://zn8octl9qmyh5wq9o-teradat
               <img src="assets/images/icons/vantage.svg" alt="Vantage image" title="Vantage">
             </div>
             <div class="slidetext1">
-              <p>Scale smarter. Innovated faster. Grow stronger.</p>
+              <p>Scale smarter. Innovate faster. Grow stronger.</p>
               <p>The complete cloud analytics and data platform, now with next-generation, cloud-native deployment and expanded analytics capabilities.</p>
          <a href="https://www.teradata.com/Vantage" class="NoDec" target="_blank">
           <button class="slide-button" >learn more</button>


### PR DESCRIPTION
Quick typo fix in the main slide of the carrousel. Innovate instead of Innovated.